### PR TITLE
Add virtual environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ real-time playback. The application requires `sounddevice` and `tkinter`.
 ### Running
 
 ```bash
-pip install sounddevice numpy
+./setup.sh
 python brown_noise_player.py
 ```
+The `setup.sh` script creates a Python virtual environment in `venv` and installs the dependencies from `requirements.txt`.
 
 Move the volume slider to adjust the output level. Choose the wave type from
 the drop-down list to switch between brown noise, white noise and a sine wave.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+sounddevice

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- add requirements.txt for dependencies
- add setup.sh to automate virtual environment creation
- update README with new instructions

## Testing
- `python brown_noise_player.py` *(fails: ModuleNotFoundError for numpy)*
- `pip install -r requirements.txt` *(fails: no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_6878e531eaec832ea714a23083036f57